### PR TITLE
fix version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 keras
 rasa-nlu-gao>=0.3.0
-rasa-sdk
+rasa-sdk~=1.1.0
 


### PR DESCRIPTION
pip install -r requirements.txt 时ERROR: rasa 1.1.8 has requirement rasa-sdk~=1.1.0, but you'll have rasa-sdk 1.2.0 which is incompatible.